### PR TITLE
remove basic/adv option

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -7,12 +7,25 @@ project_name:
     Please enter a valid project name.
     {% endif %}
   
-basic_or_advanced:
+project_type:
   type: str
-  help: Would you like to use basic or advanced features?
+  help: Which project do you want to configure your webapp with?
   choices:
     - Basic
-    - Advanced
+    - Blank
+    - HTML Button
+    - Reaction Time
+    - Multi Choice Survey
+    - Multi Select Survey
+    - Save trial parameters
+    - Lexical decision
+    - Pause/Unpause
+    - Canvas Slider Response
+    - JsPsych - Stroop
+    - JsPsych - RDK
+    - SweetBean
+    - SuperExperiment
+
 
 theorists:
   type: str
@@ -23,9 +36,9 @@ theorists:
     - autora[theorist-darts]
     - autora[theorist-bms]
     - autora[theorist-bsr]
-  when: "{{ basic_or_advanced == 'Advanced' }}"
   default: "None"
   validator: "{% if 'None' in theorists and theorists != ['None'] %}Cannot choose 'None' and another option {% endif %}"
+
 
 experimentalists:
   type: str
@@ -42,7 +55,6 @@ experimentalists:
     - autora[experimentalist-falsification]
     - autora[experimentalist-mixture]
     - autora[experimentalist-prediction-filter]
-  when: "{{ basic_or_advanced == 'Advanced' }}" 
   default: "None"
   validator: "{% if 'None' in experimentalists and experimentalists != ['None'] %}Cannot choose 'None' and another option {% endif %}"
 
@@ -50,27 +62,6 @@ firebase:
   type: bool
   help: Would you like to set up a firebase experiment?
   default: false
-  when: "{{ basic_or_advanced == 'Advanced' }}"  
-
-project_type:
-  type: str
-  help: Which project do you want to configure your webapp with?
-  choices:
-    - Blank
-    - HTML Button
-    - Reaction Time
-    - Multi Choice Survey
-    - Multi Select Survey
-    - Save trial parameters
-    - Lexical decision
-    - Pause/Unpause
-    - Canvas Slider Response
-    - JsPsych - Stroop
-    - JsPsych - RDK
-    - SweetBean
-    - SuperExperiment
-  when: "{{ firebase }}"
-
 
 _subdirectory: template
 


### PR DESCRIPTION
Remove basic/adv option from copier template. Also fixes 'KeyError' issue when choosing basic project