### PR TITLE
Restructure tests

### DIFF
--- a/template/__hooks/__postprocess.py.jinja
+++ b/template/__hooks/__postprocess.py.jinja
@@ -159,9 +159,6 @@ def write_additional_requirements():
         pathlib.Path.cwd() / "experiment" / "research_hub" / "requirements.txt"
     )
 
-    if "{{ theorists }}" == "None":
-        return
-
     if requirements_file.is_file():
         # Copier populates {{ theorists }} and {{ experimentalists }} as either a string of a list of choices if multiple are chosen
         # (for example "['autora[theorist-darts]' , 'autora[theorist-bms]']") or a string of just the chosen option (for example "autora[theorist-darts]")

--- a/template/__hooks/__postprocess.py.jinja
+++ b/template/__hooks/__postprocess.py.jinja
@@ -159,27 +159,30 @@ def write_additional_requirements():
         pathlib.Path.cwd() / "experiment" / "research_hub" / "requirements.txt"
     )
 
+    if "{{ theorists }}" == "None":
+        return
+
     if requirements_file.is_file():
         # Copier populates {{ theorists }} and {{ experimentalists }} as either a string of a list of choices if multiple are chosen
         # (for example "['autora[theorist-darts]' , 'autora[theorist-bms]']") or a string of just the chosen option (for example "autora[theorist-darts]")
         # the operations below convert everything to a string literal of a list of chosen options
         # (for example "autora[theorist-darts]" would become "['autora[theorist-darts]']")
 
-        stripped_theorist_list = "{{ theorists }}".strip("[']")
-        theorist_list_str = "['" + stripped_theorist_list + "]']"
-        stripped_exp_list = "{{ experimentalists }}".strip("[']")
-        exp_list_str = "['" + stripped_exp_list + "]']"
-
-        theorist_list = ast.literal_eval(theorist_list_str)
-        experimentalist_list = ast.literal_eval(exp_list_str)
-
-        with open(requirements_file, "a") as f:
-            if theorist_list != ["None"]:
+        if "{{ theorists }}" != "None":
+            stripped_theorist_list = "{{ theorists }}".strip("[']")
+            theorist_list_str = "['" + stripped_theorist_list + "]']"
+            theorist_list = ast.literal_eval(theorist_list_str)
+            with open(requirements_file, "a") as f:
                 for theorist in theorist_list:
                     f.write(theorist + "\n")
 
-            if experimentalist_list != ["None"]:
-                for experimentalist in experimentalist_list:
+        if "{{ experimentalists }}" != "None":
+            stripped_exp_list = "{{ experimentalists }}".strip("[']")
+            exp_list_str = "['" + stripped_exp_list + "]']"
+
+            experimentalist_list = ast.literal_eval(exp_list_str)
+            for experimentalist in experimentalist_list:
+                with open(requirements_file, "a") as f:
                     f.write(experimentalist + "\n")
 
 

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -23,7 +23,7 @@ experimentalists = [
     "['autora[experimentalist-inequality]', 'autora[experimentalist-novelty]', 'autora[experimentalist-nearest-value]']",
 ]
 firebase_options = [False, True]
-project_type = [
+project_types = [
     "Blank",
     "HTML Button",
     "Reaction Time",
@@ -40,29 +40,23 @@ project_type = [
 ]
 
 
-@pytest.fixture(scope="session", params=theorists)
-def theorist(request):
-    return request.param
+@pytest.mark.parametrize("theorist", theorists)
+@pytest.mark.parametrize("experimentalist", experimentalists)
+@pytest.mark.parametrize("firebase", firebase_options)
+@pytest.mark.parametrize("proj_type", project_types)
+@pytest.mark.filterwarnings("ignore:Dirty template changes included automatically")
+def test_all(copie, theorist, experimentalist, firebase, proj_type):
+    """Tests for copier generation. Tests have been moved into subfunctions because copie is a function scoped fixture.
+    This allows us to run all tests related to a generation at once instead of needing to regenerate for each test
 
-
-@pytest.fixture(scope="session", params=experimentalists)
-def experimentalist(request):
-    return request.param
-
-
-@pytest.fixture(scope="session", params=firebase_options)
-def firebase(request):
-    return request.param
-
-
-@pytest.fixture(scope="session", params=project_type)
-def proj_type(request):
-    return request.param
-
-
-@pytest.fixture
-def copier_result(copie, theorist, experimentalist, firebase, proj_type):
-    result = copie.copy(
+    Args:
+        copie (Any): pytest fixture responsible for running copier and cleaning up generated projects
+        theorist (str): additional theorist to install
+        experimentalist (str): additional experimentalists to install
+        firebase (bool): Bool to indicate whether or not to use firebase
+        proj_type (str): type of project to generate
+    """
+    copier_result = copie.copy(
         extra_answers={
             "project_name": "test",
             "theorists": theorist,
@@ -72,144 +66,67 @@ def copier_result(copie, theorist, experimentalist, firebase, proj_type):
         }
     )
 
-    return result
+    def test_generation():
+        """Test that project generation happens without issues"""
+        assert copier_result.exit_code == 0
+        assert copier_result.exception is None
+        assert copier_result.project_dir.is_dir()
 
+    def test_requirements():
+        """Test that requirements file has necessary dependencies"""
 
-@pytest.mark.filterwarnings("ignore:Dirty template changes included automatically")
-def test_generation(copier_result):
-    assert copier_result.exit_code == 0
-    assert copier_result.exception is None
-    assert copier_result.project_dir.is_dir()
+        assert (
+            copier_result.project_dir
+            / "experiment"
+            / "research_hub"
+            / "requirements.txt"
+        ).is_file()
 
+        with open(
+            copier_result.project_dir / "experiment/research_hub/requirements.txt", "r"
+        ) as req_file:
+            reqs = req_file.read()
+            reqs_list = reqs.split("\n")
 
-# @pytest.mark.parametrize("theorist", theorists)
-# @pytest.mark.parametrize("experimentalist", experimentalists)
-# @pytest.mark.parametrize("firebase", firebase)
-# @pytest.mark.parametrize("proj_type", project_type)
-@pytest.mark.filterwarnings("ignore:Dirty template changes included automatically")
-def test_requirements(copier_result):
-    """Test that requirements file has necessary dependencies
+            # ast.literal_eval throws a ValueError if result.answers["theorists"/"experimentalists"] returns a string of a single
+            # theorist/experimentalist instead of a list of them as would be passed in if multiple are chosen
+            # e.g. 'autora[theorist-bms]' vs '['autora[theorist-bms]', 'autora[theorist-bsr]']').
+            # By using try/except blocks, we can avoid needing to do any sort of string manipulation to handle these minor differences
+            try:
+                proj_theorists = ast.literal_eval(copier_result.answers["theorists"])
+            except ValueError:
+                proj_theorists = [copier_result.answers["theorists"]]
 
-    Args:
-        copie (Any): pytest fixture responsible for running copier and cleaning up generated projects
-        theorist (str): additional theorist to install
-        experimentalist (str): additional experimentalists to install
-        firebase (bool): Bool to indicate whether or not to use firebase
-        proj_type (str): type of project to generate
-    """
-    # result = copie.copy(
-    #     extra_answers={
-    #         "project_name": "test",
-    #         "theorists": theorist,
-    #         "experimentalists": experimentalist,
-    #         "firebase": firebase,
-    #         "project_type": proj_type,
-    #     }
-    # )
+            try:
+                proj_experimentalists = ast.literal_eval(
+                    copier_result.answers["experimentalists"]
+                )
+            except ValueError:
+                proj_experimentalists = [copier_result.answers["experimentalists"]]
 
-    result = copier_result
+            # Check that we are not adding 'None' in the requirements if it is chosen
+            if not proj_theorists or not proj_experimentalists:
+                assert "None" not in reqs_list
+            else:
+                for single_proj_theorist in proj_theorists:
+                    assert single_proj_theorist in reqs_list
 
-    # assert result.exit_code == 0
-    # assert result.exception is None
-    # assert result.project_dir.is_dir()
+                for single_proj_experimentalist in proj_experimentalists:
+                    assert single_proj_experimentalist in reqs_list
 
-    assert (
-        result.project_dir / "experiment" / "research_hub" / "requirements.txt"
-    ).is_file()
+    def test_package_build():
+        """Test that Vite can bundle the code without errors"""
+        assert copier_result.project_dir.is_dir()
 
-    with open(
-        result.project_dir / "experiment/research_hub/requirements.txt", "r"
-    ) as req_file:
-        reqs = req_file.read()
-        reqs_list = reqs.split("\n")
+        res = subprocess.run(
+            "npm run build",
+            shell=True,
+            check=False,
+            cwd=(copier_result.project_dir / "experiment"),
+        )
 
-        # ast.literal_eval throws a ValueError if result.answers["theorists"/"experimentalists"] returns a string of a single
-        # theorist/experimentalist instead of a list of them as would be passed in if multiple are chosen
-        # e.g. 'autora[theorist-bms]' vs '['autora[theorist-bms]', 'autora[theorist-bsr]']').
-        # By using try/except blocks, we can avoid needing to do any sort of string manipulation to handle these minor differences
-        try:
-            proj_theorists = ast.literal_eval(result.answers["theorists"])
-        except ValueError:
-            proj_theorists = [result.answers["theorists"]]
+        assert res.returncode == 0
 
-        try:
-            proj_experimentalists = ast.literal_eval(result.answers["experimentalists"])
-        except ValueError:
-            proj_experimentalists = [result.answers["experimentalists"]]
-
-        # Check that we are not adding 'None' in the requirements if it is chosen
-        if not proj_theorists or not proj_experimentalists:
-            assert "None" not in reqs_list
-        else:
-            assert isinstance(proj_theorists, list)
-            assert isinstance(proj_experimentalists, list)
-
-            for single_proj_theorist in proj_theorists:
-                assert single_proj_theorist in reqs_list
-
-            for single_proj_experimentalist in proj_experimentalists:
-                assert single_proj_experimentalist in reqs_list
-
-
-@pytest.mark.filterwarnings("ignore:Dirty template changes included automatically")
-def test_package_build(copier_result):
-    assert copier_result.project_dir.is_dir()
-
-    res = subprocess.run(
-        "npm run build",
-        shell=True,
-        check=False,
-        cwd=(copier_result.project_dir / "experiment"),
-    )
-
-    assert res.returncode == 0
-
-
-# @pytest.mark.parametrize("firebase", firebase)
-# @pytest.mark.parametrize("proj_type", project_type)
-# @pytest.mark.filterwarnings("ignore:Dirty template changes included automatically")
-# def test_multiselect(copie, firebase, proj_type):
-#     """Test project generation and requirements when selecting multiple theorists and experimentalists
-
-#     Args:
-#         copie (Any): pytest fixture responsible for running copier and cleaning up generated projects
-#         firebase (bool): Bool to indicate whether or not to use firebase
-#         proj_type (str): type of project to generate
-#     """
-#     theorists = [
-#         "autora[experimentalist-inequality]",
-#         "autora[experimentalist-uncertainty]",
-#     ]
-#     experimentalists = [
-#         "autora[experimentalist-inequality]",
-#         "autora[experimentalist-novelty]",
-#         "autora[experimentalist-nearest-value]",
-#     ]
-#     result = copie.copy(
-#         extra_answers={
-#             "project_name": "test",
-#             "theorists": str(theorists),
-#             "experimentalists": str(experimentalists),
-#             "firebase": firebase,
-#             "project_type": proj_type,
-#         }
-#     )
-
-#     assert result.exit_code == 0
-#     assert result.project_dir.is_dir()
-
-#     assert (
-#         result.project_dir / "experiment" / "research_hub" / "requirements.txt"
-#     ).is_file()
-
-#     with open(
-#         result.project_dir / "experiment/research_hub/requirements.txt", "r"
-#     ) as req_file:
-#         reqs = req_file.read()
-#         reqs_list = reqs.split("\n")
-
-#         for theorist in theorists:
-#             assert (theorist in reqs_list) == (theorist != "None")
-
-#         for experimentalist in experimentalists:
-#             assert (experimentalist in reqs_list) == (experimentalist != "None")
+    test_generation()
+    test_requirements()
+    test_package_build()

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,3 +1,4 @@
+import ast
 import pytest
 import subprocess
 
@@ -6,6 +7,7 @@ theorists = [
     "autora[theorist-darts]",
     "autora[theorist-bms]",
     "autora[theorist-bsr]",
+    "['autora[theorist-bms]', 'autora[theorist-bsr]']",
 ]
 experimentalists = [
     "None",
@@ -18,8 +20,9 @@ experimentalists = [
     "autora[experimentalist-falsification]",
     "autora[experimentalist-mixture]",
     "autora[experimentalist-prediction-filter]",
+    "['autora[experimentalist-inequality]', 'autora[experimentalist-novelty]', 'autora[experimentalist-nearest-value]']",
 ]
-firebase = [False, True]
+firebase_options = [False, True]
 project_type = [
     "Blank",
     "HTML Button",
@@ -37,21 +40,28 @@ project_type = [
 ]
 
 
-@pytest.mark.parametrize("theorist", theorists)
-@pytest.mark.parametrize("experimentalist", experimentalists)
-@pytest.mark.parametrize("firebase", firebase)
-@pytest.mark.parametrize("proj_type", project_type)
-@pytest.mark.filterwarnings("ignore:Dirty template changes included automatically")
-def test_requirements(copie, theorist, experimentalist, firebase, proj_type):
-    """Test that requirements file has necessary dependencies
+@pytest.fixture(scope="session", params=theorists)
+def theorist(request):
+    return request.param
 
-    Args:
-        copie (Any): pytest fixture responsible for running copier and cleaning up generated projects
-        theorist (str): additional theorist to install
-        experimentalist (str): additional experimentalists to install
-        firebase (bool): Bool to indicate whether or not to use firebase
-        proj_type (str): type of project to generate
-    """
+
+@pytest.fixture(scope="session", params=experimentalists)
+def experimentalist(request):
+    return request.param
+
+
+@pytest.fixture(scope="session", params=firebase_options)
+def firebase(request):
+    return request.param
+
+
+@pytest.fixture(scope="session", params=project_type)
+def proj_type(request):
+    return request.param
+
+
+@pytest.fixture
+def copier_result(copie, theorist, experimentalist, firebase, proj_type):
     result = copie.copy(
         extra_answers={
             "project_name": "test",
@@ -62,78 +72,144 @@ def test_requirements(copie, theorist, experimentalist, firebase, proj_type):
         }
     )
 
-    assert result.exit_code == 0
-    assert result.exception is None
-    assert result.project_dir.is_dir()
+    return result
+
+
+@pytest.mark.filterwarnings("ignore:Dirty template changes included automatically")
+def test_generation(copier_result):
+    assert copier_result.exit_code == 0
+    assert copier_result.exception is None
+    assert copier_result.project_dir.is_dir()
+
+
+# @pytest.mark.parametrize("theorist", theorists)
+# @pytest.mark.parametrize("experimentalist", experimentalists)
+# @pytest.mark.parametrize("firebase", firebase)
+# @pytest.mark.parametrize("proj_type", project_type)
+@pytest.mark.filterwarnings("ignore:Dirty template changes included automatically")
+def test_requirements(copier_result):
+    """Test that requirements file has necessary dependencies
+
+    Args:
+        copie (Any): pytest fixture responsible for running copier and cleaning up generated projects
+        theorist (str): additional theorist to install
+        experimentalist (str): additional experimentalists to install
+        firebase (bool): Bool to indicate whether or not to use firebase
+        proj_type (str): type of project to generate
+    """
+    # result = copie.copy(
+    #     extra_answers={
+    #         "project_name": "test",
+    #         "theorists": theorist,
+    #         "experimentalists": experimentalist,
+    #         "firebase": firebase,
+    #         "project_type": proj_type,
+    #     }
+    # )
+
+    result = copier_result
+
+    # assert result.exit_code == 0
+    # assert result.exception is None
+    # assert result.project_dir.is_dir()
+
+    assert (
+        result.project_dir / "experiment" / "research_hub" / "requirements.txt"
+    ).is_file()
+
+    with open(
+        result.project_dir / "experiment/research_hub/requirements.txt", "r"
+    ) as req_file:
+        reqs = req_file.read()
+        reqs_list = reqs.split("\n")
+
+        # ast.literal_eval throws a ValueError if result.answers["theorists"/"experimentalists"] returns a string of a single
+        # theorist/experimentalist instead of a list of them as would be passed in if multiple are chosen
+        # e.g. 'autora[theorist-bms]' vs '['autora[theorist-bms]', 'autora[theorist-bsr]']').
+        # By using try/except blocks, we can avoid needing to do any sort of string manipulation to handle these minor differences
+        try:
+            proj_theorists = ast.literal_eval(result.answers["theorists"])
+        except ValueError:
+            proj_theorists = [result.answers["theorists"]]
+
+        try:
+            proj_experimentalists = ast.literal_eval(result.answers["experimentalists"])
+        except ValueError:
+            proj_experimentalists = [result.answers["experimentalists"]]
+
+        # Check that we are not adding 'None' in the requirements if it is chosen
+        if not proj_theorists or not proj_experimentalists:
+            assert "None" not in reqs_list
+        else:
+            assert isinstance(proj_theorists, list)
+            assert isinstance(proj_experimentalists, list)
+
+            for single_proj_theorist in proj_theorists:
+                assert single_proj_theorist in reqs_list
+
+            for single_proj_experimentalist in proj_experimentalists:
+                assert single_proj_experimentalist in reqs_list
+
+
+@pytest.mark.filterwarnings("ignore:Dirty template changes included automatically")
+def test_package_build(copier_result):
+    assert copier_result.project_dir.is_dir()
 
     res = subprocess.run(
         "npm run build",
         shell=True,
         check=False,
-        cwd=(result.project_dir / "experiment"),
+        cwd=(copier_result.project_dir / "experiment"),
     )
 
     assert res.returncode == 0
 
-    assert (
-        result.project_dir / "experiment" / "research_hub" / "requirements.txt"
-    ).is_file()
 
-    with open(
-        result.project_dir / "experiment/research_hub/requirements.txt", "r"
-    ) as req_file:
-        reqs = req_file.read()
-        reqs_list = reqs.split("\n")
+# @pytest.mark.parametrize("firebase", firebase)
+# @pytest.mark.parametrize("proj_type", project_type)
+# @pytest.mark.filterwarnings("ignore:Dirty template changes included automatically")
+# def test_multiselect(copie, firebase, proj_type):
+#     """Test project generation and requirements when selecting multiple theorists and experimentalists
 
-        assert (theorist in reqs_list) == (theorist != "None")
-        assert (experimentalist in reqs_list) == (experimentalist != "None")
+#     Args:
+#         copie (Any): pytest fixture responsible for running copier and cleaning up generated projects
+#         firebase (bool): Bool to indicate whether or not to use firebase
+#         proj_type (str): type of project to generate
+#     """
+#     theorists = [
+#         "autora[experimentalist-inequality]",
+#         "autora[experimentalist-uncertainty]",
+#     ]
+#     experimentalists = [
+#         "autora[experimentalist-inequality]",
+#         "autora[experimentalist-novelty]",
+#         "autora[experimentalist-nearest-value]",
+#     ]
+#     result = copie.copy(
+#         extra_answers={
+#             "project_name": "test",
+#             "theorists": str(theorists),
+#             "experimentalists": str(experimentalists),
+#             "firebase": firebase,
+#             "project_type": proj_type,
+#         }
+#     )
 
+#     assert result.exit_code == 0
+#     assert result.project_dir.is_dir()
 
-@pytest.mark.parametrize("firebase", firebase)
-@pytest.mark.parametrize("proj_type", project_type)
-@pytest.mark.filterwarnings("ignore:Dirty template changes included automatically")
-def test_multiselect(copie, firebase, proj_type):
-    """Test project generation and requirements when selecting multiple theorists and experimentalists
+#     assert (
+#         result.project_dir / "experiment" / "research_hub" / "requirements.txt"
+#     ).is_file()
 
-    Args:
-        copie (Any): pytest fixture responsible for running copier and cleaning up generated projects
-        firebase (bool): Bool to indicate whether or not to use firebase
-        proj_type (str): type of project to generate
-    """
-    theorists = [
-        "autora[experimentalist-inequality]",
-        "autora[experimentalist-uncertainty]",
-    ]
-    experimentalists = [
-        "autora[experimentalist-inequality]",
-        "autora[experimentalist-novelty]",
-        "autora[experimentalist-nearest-value]",
-    ]
-    result = copie.copy(
-        extra_answers={
-            "project_name": "test",
-            "theorists": str(theorists),
-            "experimentalists": str(experimentalists),
-            "firebase": firebase,
-            "project_type": proj_type,
-        }
-    )
+#     with open(
+#         result.project_dir / "experiment/research_hub/requirements.txt", "r"
+#     ) as req_file:
+#         reqs = req_file.read()
+#         reqs_list = reqs.split("\n")
 
-    assert result.exit_code == 0
-    assert result.project_dir.is_dir()
+#         for theorist in theorists:
+#             assert (theorist in reqs_list) == (theorist != "None")
 
-    assert (
-        result.project_dir / "experiment" / "research_hub" / "requirements.txt"
-    ).is_file()
-
-    with open(
-        result.project_dir / "experiment/research_hub/requirements.txt", "r"
-    ) as req_file:
-        reqs = req_file.read()
-        reqs_list = reqs.split("\n")
-
-        for theorist in theorists:
-            assert (theorist in reqs_list) == (theorist != "None")
-
-        for experimentalist in experimentalists:
-            assert (experimentalist in reqs_list) == (experimentalist != "None")
+#         for experimentalist in experimentalists:
+#             assert (experimentalist in reqs_list) == (experimentalist != "None")


### PR DESCRIPTION
## Changes
Earlier tests had multiple tests within a single test function. This PR splits up the tests into separate subfunctions within a single function to run all tests for a given project generation. Subfunctions need to be used since the imported `copie` fixture is function scoped so there is no other work around to prevent the overhead of needing to go through a new generation for every test