### PR TITLE
commenting out currently unused env var check so that docker loads the experiment instead of a blank page

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -37,7 +37,7 @@ RUN python3 -m venv venv
 RUN . venv/bin/activate
 # install Python dependencies into virtual environment
 RUN ./venv/bin/python -m pip install -r ${BASE_PATH}/server/requirements.txt
-ENV PATH=${BASE_PATH}
+ENV PATH=${BASE_PATH}/server
 RUN unset VIRTUAL_ENV
 
 # expose web port

--- a/template/experiment/index.js
+++ b/template/experiment/index.js
@@ -1,18 +1,18 @@
 // TODO: remove unused imports once firebase dependency is removed
 
-import { waitPage, endPage, errorPage } from "./pages";
+// import { waitPage, endPage, errorPage } from "./pages";
 // import { getCondition, setObservation, setBackup } from "autora-firebase-functions";
 import main from "./main"
 // import db from "./firebase"
 
 const index = async () => {
-    if (process.env.NODE_ENV === 'development' && process.env.NODE_APP_devNoDb === 'True') {
-        await main(0, 0)
-        return
-    }
+    // if (process.env.NODE_ENV === 'development' && process.env.NODE_APP_devNoDb === 'True') {
+    await main(0, 0)
+    return
+    // }
 
-    //TODO: rewrite without firebase dependency
-    let prolificId = null
+// TODO: rewrite without firebase dependency
+/* let prolificId = null
     if (process.env.NODE_APP_useProlificId === 'True') {
         const queryString = window.location.search;
         const urlParams = new URLSearchParams(queryString);
@@ -28,6 +28,6 @@ const index = async () => {
         endPage()
     } else {
         errorPage()
-    }
+    } */
 }
 await index()


### PR DESCRIPTION
The env vars will be revisited as part of impending changes to [optionally] write to a file instead of a db. Committing this so that I can create a PR for GitHub Actions that deploy the docker container to a server and the resulting web app will function.