### PR TITLE
Reintroduce support for firebase

### DIFF
--- a/template/experiment/index.js.jinja
+++ b/template/experiment/index.js.jinja
@@ -1,6 +1,12 @@
 import { errorPage } from "./pages";
-import { getCondition } from "./autora-filestore-functions"
 import main from "./main"
+{% if firebase %}
+import { getCondition, setObservation, setBackup } from "autora-firebase-functions";
+import db from "./firebase"
+import { waitPage, endPage } from "./pages";
+{% else %}
+import { getCondition } from "./autora-filestore-functions"
+{% endif %}
 
 
 const index = async () => {
@@ -18,7 +24,15 @@ const index = async () => {
     let prolificId = "1" // TODO: replace with pID
     let condition = await getCondition('autora', prolificId)
     if (condition && (prolificId !== null || process.env.NODE_APP_useProlificId === 'False')) {
+        {% if firebase %}
+        let observation = await main(condition[0], condition[1])
+        waitPage()
+        await setObservation(db, 'autora', condition[0], observation)
+        await setBackup(db, 'autora', condition[0], condition[1], observation)
+        endPage()
+        {% else %}
         await main(condition[0], condition[1])
+        {% endif %}
     } else {
         errorPage()
     }

--- a/template/experiment/package.json.jinja
+++ b/template/experiment/package.json.jinja
@@ -26,6 +26,7 @@
     {% if project_type in ['Basic', 'JsPsych - RDK']%}"@jspsych-contrib/plugin-rdk": "*",{% endif %}
     {% if project_type in ['Blank']%}"@jspsych/plugin-browser-check": "*",{% endif %}
     {% if project_type == 'SuperExperiment' %}"super-experiment": "*",{% endif %}
+    {% if firebase %}"autora-firebase-functions": "*",{% endif %}
     "axios": "^1.7.4",
     "jspsych": "^7.3.4"
   }

--- a/template/experiment/{% if firebase %}firebase.js{% endif %}
+++ b/template/experiment/{% if firebase %}firebase.js{% endif %}
@@ -1,0 +1,17 @@
+import {initializeApp} from "firebase/app";
+import {getFirestore} from "firebase/firestore"
+
+const firebaseConfig = {
+    apiKey: process.env.REACT_APP_apiKey,
+    authDomain: process.env.REACT_APP_authDomain,
+    databaseURL: process.env.REACT_APP_databaseURL,
+    projectId: process.env.REACT_APP_projectId,
+    storageBucket: process.env.REACT_APP_storageBucket,
+    messagingSenderId: process.env.REACT_APP_messagingSenderId,
+    appId: process.env.REACT_APP_appId,
+};
+
+
+const app = initializeApp(firebaseConfig);
+
+export default getFirestore(app)

--- a/template/experiment/{% if firebase %}firebase.js{% endif %}
+++ b/template/experiment/{% if firebase %}firebase.js{% endif %}
@@ -2,13 +2,13 @@ import {initializeApp} from "firebase/app";
 import {getFirestore} from "firebase/firestore"
 
 const firebaseConfig = {
-    apiKey: process.env.REACT_APP_apiKey,
-    authDomain: process.env.REACT_APP_authDomain,
-    databaseURL: process.env.REACT_APP_databaseURL,
-    projectId: process.env.REACT_APP_projectId,
-    storageBucket: process.env.REACT_APP_storageBucket,
-    messagingSenderId: process.env.REACT_APP_messagingSenderId,
-    appId: process.env.REACT_APP_appId,
+    apiKey: process.env.NODE_APP_apiKey,
+    authDomain: process.env.NODE_APP_authDomain,
+    databaseURL: process.env.NODE_APP_databaseURL,
+    projectId: process.env.NODE_APP_projectId,
+    storageBucket: process.env.NODE_APP_storageBucket,
+    messagingSenderId: process.env.NODE_APP_messagingSenderId,
+    appId: process.env.NODE_APP_appId,
 };
 
 

--- a/template/experiment/{% if not firebase %}autora-filestore-functions.js{% endif %}
+++ b/template/experiment/{% if not firebase %}autora-filestore-functions.js{% endif %}
@@ -16,7 +16,4 @@ const getCondition = async (study, pId = null) => {
     return false;
 }
 
-
-
-
 export { getCondition }

--- a/template/experiment/{% if not firebase %}autora-filestore-functions.js{% endif %}
+++ b/template/experiment/{% if not firebase %}autora-filestore-functions.js{% endif %}
@@ -12,8 +12,11 @@ const getCondition = async (study, pId = null) => {
             return return_arr
         }
     }
+
     return false;
 }
+
+
 
 
 export { getCondition }


### PR DESCRIPTION
## Changes
- added support for using firebase
- Conditionally generate appropriate logic for writing/reading from firebase or for reading from conditions locally based on user's copier answers
- Logic for firebase mimics the logic from the original cookiecutter repo
- Change some files to be conditionally generated if they are not needed when using firebase

### Note:
Changes to follow in a new PR:
- Need to update logic for saving data locally upon completion of experiment to happen only if we do not choose firebase
- Need to change change `autora_out.json` to be conditionally generated only if we do not choose firebase

